### PR TITLE
Typo for gecko-t-win10-64-ux

### DIFF
--- a/provisioners.json
+++ b/provisioners.json
@@ -61,7 +61,7 @@
             "3":"gecko-t-linux-talos",
             "4":"gecko-t-linux-talos-b",
             "5":"gecko-t-osx-1010-beta",
-            "6":"gecko-t-win10-64-us"
+            "6":"gecko-t-win10-64-ux"
         }        
     }
 }


### PR DESCRIPTION
There is a typo where gecko-t-win10-64-ux is called `gecko-t-win10-64-us`